### PR TITLE
Use commandline tool for sending XMPP messages.

### DIFF
--- a/README
+++ b/README
@@ -5,6 +5,11 @@ a detatched terminal where you're not always looking at your IRC window.
 Requires SleekXMPP (`pip install sleekxmpp`)
 
 Changelog:
+ * 0.6:
+   - switch from sleekxmpp to commandline utility sendxmpp 
+     (https://github.com/lhost/sendxmpp) or go-sendxmpp 
+     (https://salsa.debian.org/mdosch/go-sendxmpp).
+
  * 0.5:
    - switch to sleekxmpp as xmpp library (http://github.com/fritzy/SleekXMPP)
 


### PR DESCRIPTION
Loading sleekxmpp library with current Weechat version, causes to
highlightxmpp to fail. Probable reason is that sleekxmpp heavily uses
threading, while Weechat docs[1] clearly states, that threads shouldn't
be used.

[1] https://weechat.org/files/doc/stable/weechat_scripting.en.html#weechat_architecture